### PR TITLE
Complete files from pwd

### DIFF
--- a/autoload/asyncomplete/sources/file.vim
+++ b/autoload/asyncomplete/sources/file.vim
@@ -11,6 +11,22 @@ function! s:filename_map(prefix, file) abort
         \ }
 endfunction
 
+function! s:matches_for_prefix(pre, cwd) abort
+  let l:pre = a:pre
+  let l:cwd = a:cwd
+
+  let l:glob = fnamemodify(l:cwd, ':t') . '*'
+  let l:cwd  = fnamemodify(l:cwd, ':p:h')
+
+  if l:pre !~ '/$'
+    let l:pre = l:pre . '/'
+  endif
+
+  let l:cwdlen   = strlen(l:cwd)
+  let l:files    = split(globpath(l:cwd, l:glob), '\n')
+  return map(l:files, {key, val -> s:filename_map(l:pre, val)})
+endfunction
+
 function! asyncomplete#sources#file#completor(opt, ctx)
   let l:bufnr = a:ctx['bufnr']
   let l:typed = a:ctx['typed']
@@ -18,30 +34,23 @@ function! asyncomplete#sources#file#completor(opt, ctx)
 
   let l:kw    = matchstr(l:typed, '<\@<!\.\{0,2}/.*$')
   let l:kwlen = len(l:kw)
+  let l:pre  = fnamemodify(l:kw, ':h')
 
   if l:kwlen < 1
     return
   endif
 
   if l:kw !~ '^/'
-    let l:cwd = expand('#' . l:bufnr . ':p:h') . '/' . l:kw
+    let l:filecwd = expand('#' . l:bufnr . ':p:h') . '/' . l:kw
+    let l:pwd     = getcwd() . '/' . l:kw
+
+    let l:matches = s:matches_for_prefix(l:pre, l:filecwd) + s:matches_for_prefix(l:pre, l:pwd)
   else
     let l:cwd = l:kw
+	let l:matches = s:matches_for_prefix(l:pre, l:filecwd)
   endif
 
-  let l:glob = fnamemodify(l:cwd, ':t') . '*'
-  let l:cwd  = fnamemodify(l:cwd, ':p:h')
-  let l:pre  = fnamemodify(l:kw, ':h')
-
-  if l:pre !~ '/$'
-    let l:pre = l:pre . '/'
-  endif
-
-  let l:cwdlen   = strlen(l:cwd)
   let l:startcol = l:col - l:kwlen
-  let l:files    = split(globpath(l:cwd, l:glob), '\n')
-  let l:matches  = map(l:files, {key, val -> s:filename_map(l:pre, val)})
-
   call asyncomplete#complete(a:opt['name'], a:ctx, l:startcol, l:matches)
 endfunction
 


### PR DESCRIPTION
Often, it is useful to not only complete relative filepaths as relative
to the currently edited file, but also to complete files relative to
the current processes cwd (one example being scripts like sudoedit which copy the
script into a temporary file under /tmp by default and perform their
edits there but do not modify the cwd). This commit enables completion of files relative to the processes cwd.

This pull request currently is more a proposal, as it currently enables completion from pwd unconditionally.
However, this might not be desired in all cases. Yet, traditional approaches (such as matching on filetypes, having a bufferlocal enable/disable etc) all seem cumbersome to use for the end user. Furthermore, I personally do not see too much harm in enabling this completion variant globally (after all, the plugin runs async and the only visible result is a small number of additional completion candidates).