### PR TITLE
Fix for Windows

### DIFF
--- a/autoload/asyncomplete/sources/file.vim
+++ b/autoload/asyncomplete/sources/file.vim
@@ -37,7 +37,11 @@ function! asyncomplete#sources#file#completor(opt, ctx)
     let l:cwd = l:kw
   endif
 
-  let l:glob = fnamemodify(l:cwd, ':t') . '.\=[^.]*'
+  if has('win32')
+    let l:glob = fnamemodify(l:cwd, ':t') . '*'
+  else
+    let l:glob = fnamemodify(l:cwd, ':t') . '.\=[^.]*'
+  endif
   let l:cwd  = fnamemodify(l:cwd, ':p:h')
   let l:pre  = fnamemodify(l:kw, ':h')
 


### PR DESCRIPTION
`globpath(cwd, '.\=[^.]*')` does not work on Windows